### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/src/TestDatabase.php
+++ b/src/TestDatabase.php
@@ -148,7 +148,7 @@ abstract class TestDatabase extends \PHPUnit_Extensions_Database_TestCase
 	{
 		if (!is_null(self::$driver))
 		{
-			return $this->createDefaultDBConnection(self::$driver->getConnection(), ':memory:');
+			return $this->createDefaultDbConnection(self::$driver->getConnection(), ':memory:');
 		}
 
 		return null;
@@ -163,7 +163,7 @@ abstract class TestDatabase extends \PHPUnit_Extensions_Database_TestCase
 	 */
 	protected function getDataSet()
 	{
-		return $this->createXMLDataSet(__DIR__ . '/Stubs/empty.xml');
+		return $this->createXmlDataSet(__DIR__ . '/Stubs/empty.xml');
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).