### PR TITLE
Package cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,15 @@
     "homepage": "https://github.com/joomla-framework/test",
     "license": "GPL-2.0+",
     "require": {
-        "php": ">=5.3.10"
+        "php": "^5.3.10|~7.0"
     },
     "require-dev": {
-        "joomla/database": "~1.0"
+        "joomla/database": "~1.0",
+        "phpunit/dbunit": "~1.3|~2.0"
     },
     "suggest": {
-        "joomla/database": "To use the database test case, install joomla/database"
+        "joomla/database": "To use the database test case, install joomla/database",
+        "phpunit/dbunit": "To use the database test case, install phpunit/dbunit"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "homepage": "https://github.com/joomla-framework/test",
     "license": "GPL-2.0+",
     "require": {
-        "php": "^5.3.10|~7.0"
+        "php": "^5.3.10|~7.0",
+        "phpunit/phpunit": "^4.8.35|^5.4.3|~6.0"
     },
     "require-dev": {
         "joomla/database": "~1.0",

--- a/src/TestConfig.php
+++ b/src/TestConfig.php
@@ -11,7 +11,8 @@ namespace Joomla\Test;
 /**
  * Test stub configuration class.
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0  Deprecated without replacement
  */
 class Config
 {

--- a/src/TestDatabase.php
+++ b/src/TestDatabase.php
@@ -38,7 +38,7 @@ abstract class TestDatabase extends \PHPUnit_Extensions_Database_TestCase
 	{
 		if (!class_exists('\\Joomla\\Database\\DatabaseDriver'))
 		{
-			static::fail('The joomla/database package is not installed, cannot use this test case.');
+			static::markTestSkipped('The joomla/database package is not installed, cannot use this test case.');
 		}
 
 		// Make sure the driver is supported
@@ -49,9 +49,9 @@ abstract class TestDatabase extends \PHPUnit_Extensions_Database_TestCase
 
 		// We always want the default database test case to use an SQLite memory database.
 		$options = array(
-			'driver' => 'sqlite',
+			'driver'   => 'sqlite',
 			'database' => ':memory:',
-			'prefix' => 'jos_'
+			'prefix'   => 'jos_',
 		);
 
 		try

--- a/src/TestDatabase.php
+++ b/src/TestDatabase.php
@@ -95,26 +95,11 @@ abstract class TestDatabase extends \PHPUnit_Extensions_Database_TestCase
 	 *
 	 * @note    This method assumes that the mock callback is named {mock}{method name}.
 	 * @since   1.0
+	 * @deprecated  2.0  Use TestHelper::assignMockCallbacks instead
 	 */
 	public function assignMockCallbacks($mockObject, $array)
 	{
-		foreach ($array as $index => $method)
-		{
-			if (is_array($method))
-			{
-				$methodName = $index;
-				$callback = $method;
-			}
-			else
-			{
-				$methodName = $method;
-				$callback = array(get_called_class(), 'mock' . $method);
-			}
-
-			$mockObject->expects($this->any())
-				->method($methodName)
-				->will($this->returnCallback($callback));
-		}
+		TestHelper::assignMockCallbacks($mockObject, $this, $array);
 	}
 
 	/**
@@ -128,15 +113,11 @@ abstract class TestDatabase extends \PHPUnit_Extensions_Database_TestCase
 	 * @return  void
 	 *
 	 * @since   1.0
+	 * @deprecated  2.0  Use TestHelper::assignMockReturns instead
 	 */
 	public function assignMockReturns($mockObject, $array)
 	{
-		foreach ($array as $method => $return)
-		{
-			$mockObject->expects($this->any())
-				->method($method)
-				->will($this->returnValue($return));
-		}
+		TestHelper::assignMockReturns($mockObject, $this, $array);
 	}
 
 	/**

--- a/src/TestDatabase.php
+++ b/src/TestDatabase.php
@@ -10,7 +10,6 @@ namespace Joomla\Test;
 
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Sqlite\SqliteDriver;
-use Joomla\Test\TestHelper;
 
 /**
  * Abstract test case class for database testing.
@@ -123,7 +122,7 @@ abstract class TestDatabase extends \PHPUnit_Extensions_Database_TestCase
 	/**
 	 * Returns the default database connection for running the tests.
 	 *
-	 * @return  \PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection
+	 * @return  \PHPUnit_Extensions_Database_DB_IDatabaseConnection
 	 *
 	 * @since   1.0
 	 */
@@ -140,7 +139,7 @@ abstract class TestDatabase extends \PHPUnit_Extensions_Database_TestCase
 	/**
 	 * Gets the data set to be loaded into the database during setup
 	 *
-	 * @return  \PHPUnit_Extensions_Database_DataSet_XmlDataSet
+	 * @return  \PHPUnit_Extensions_Database_DataSet_IDataSet
 	 *
 	 * @since   1.0
 	 */
@@ -152,7 +151,7 @@ abstract class TestDatabase extends \PHPUnit_Extensions_Database_TestCase
 	/**
 	 * Returns the database operation executed in test setup.
 	 *
-	 * @return  \PHPUnit_Extensions_Database_Operation_Composite
+	 * @return  \PHPUnit_Extensions_Database_Operation_IDatabaseOperation
 	 *
 	 * @since   1.0
 	 */
@@ -170,7 +169,7 @@ abstract class TestDatabase extends \PHPUnit_Extensions_Database_TestCase
 	/**
 	 * Returns the database operation executed in test cleanup.
 	 *
-	 * @return  \PHPUnit_Extensions_Database_Operation_Factory
+	 * @return  \PHPUnit_Extensions_Database_Operation_IDatabaseOperation
 	 *
 	 * @since   1.0
 	 */

--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\Test;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Static helper methods to assist unit testing PHP code.
  *
@@ -21,14 +23,14 @@ class TestHelper
 	 * This method assumes that the mock callback is named {mock}{method name}.
 	 *
 	 * @param   \PHPUnit_Framework_MockObject_MockObject  $mockObject  The mock object that the callbacks are being assigned to.
-	 * @param   \PHPUnit_Framework_TestCase               $test        The test.
+	 * @param   TestCase                                  $test        The test.
 	 * @param   array                                     $array       An array of methods names to mock with callbacks.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
 	 */
-	public static function assignMockCallbacks(\PHPUnit_Framework_MockObject_MockObject $mockObject, \PHPUnit_Framework_TestCase $test, $array)
+	public static function assignMockCallbacks(\PHPUnit_Framework_MockObject_MockObject $mockObject, TestCase $test, $array)
 	{
 		foreach ($array as $index => $method)
 		{
@@ -53,7 +55,7 @@ class TestHelper
 	 * Assigns mock values to methods.
 	 *
 	 * @param   \PHPUnit_Framework_MockObject_MockObject  $mockObject  The mock object.
-	 * @param   \PHPUnit_Framework_TestCase               $test        The test.
+	 * @param   TestCase                                  $test        The test.
 	 * @param   array                                     $array       An associative array of methods to mock with return values:<br />
 	 *                                                                 string (method name) => mixed (return value)
 	 *
@@ -61,7 +63,7 @@ class TestHelper
 	 *
 	 * @since   1.0
 	 */
-	public static function assignMockReturns(\PHPUnit_Framework_MockObject_MockObject $mockObject, \PHPUnit_Framework_TestCase $test, $array)
+	public static function assignMockReturns(\PHPUnit_Framework_MockObject_MockObject $mockObject, TestCase $test, $array)
 	{
 		foreach ($array as $method => $return)
 		{

--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -45,7 +45,7 @@ class TestHelper
 
 			$mockObject->expects($test->any())
 				->method($methodName)
-				->will($test->returnCallback($callback));
+				->willReturnCallback($callback);
 		}
 	}
 
@@ -67,7 +67,7 @@ class TestHelper
 		{
 			$mockObject->expects($test->any())
 				->method($method)
-				->will($test->returnValue($return));
+				->willReturn($return);
 		}
 	}
 

--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -34,7 +34,7 @@ class TestHelper
 	{
 		foreach ($array as $index => $method)
 		{
-			if (is_array($method))
+			if (is_callable($method))
 			{
 				$methodName = $index;
 				$callback = $method;

--- a/src/WebInspector.php
+++ b/src/WebInspector.php
@@ -13,7 +13,8 @@ use Joomla\Application\AbstractWebApplication;
 /**
  * Inspector for the Joomla\Application\AbstractWebApplication class.
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0  Deprecated without replacement
  */
 class WebInspector extends AbstractWebApplication
 {


### PR DESCRIPTION
1) Declare PHPUnit and DBUnit dependencies
2) Deprecate the web inspector and stub config objects, implement them if needed in your projects
3) Don't fail tests if the database package is missing, just skip them
4) Deprecate duplicate methods in TestDatabase, use TestHelper instead
5) Allow all callables in the `assignMockCallbacks` helper
6) B/C break - Change the typehint on `assignMockCallbacks` and `assignMockReturns` methods to use the namespaced PHPUnit classes, this sets the version constraints to `^4.8.35|^5.4.3|~6.0` (previously undeclared but in effect it was `4.*|5.*`