### PR TITLE
PHPUnit Compatibility Layer

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,61 @@
+build: false
+platform:
+  - x64
+clone_folder: C:\projects\filesystem
+
+branches:
+  except:
+    - gh-pages
+
+## Build matrix for lowest and highest possible targets
+environment:
+  PHPBuild: "x64"
+  VC: "vc15"
+  WINCACHE: "2.0.0.8"
+  matrix:
+  - php_ver_target: 5.3.10
+  - php_ver_target: 5.3.29
+  - php_ver_target: 5.4.45
+  - php_ver_target: 7.0.33
+  - php_ver_target: 7.1.33
+  - php_ver_target: 7.2.34
+  - php_ver_target: 7.3.33
+  - php_ver_target: 7.4.26
+  - php_ver_target: 8.0.13
+
+init:
+  - SET PATH=C:\Program Files\OpenSSL;C:\tools\php;%PATH%
+  - SET COMPOSER_NO_INTERACTION=1
+  - SET PHP=1 # This var relates to caching the php install
+  - SET ANSICON=121x90 (121x90)
+
+## Install PHP and composer, and run the appropriate composer command
+install:
+    - IF EXIST C:\tools\php (SET PHP=0)
+    - ps: >-
+        If ($env:PHP -eq "1") {
+            appveyor-retry cinst php --version=$env:php_ver_target --package-parameters='""/InstallDir:C:\tools\php""' --ignore-checksums -y --no-progress --limit-output
+        }
+    - cd C:\tools\php
+    - IF %PHP%==1 copy php.ini-production php.ini /Y
+    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
+    - IF %PHP%==1 echo extension_dir=ext >> php.ini
+    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_ftp.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_gd2.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_gmp.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_pgsql.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_curl.dll >> php.ini
+    - IF %PHP%==1 echo zend_extension=php_opcache.dll >> php.ini
+    - IF %PHP%==1 echo opcache.enable_cli=1 >> php.ini
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+    - IF %PHP%==1 php -r "readfile('http://getcomposer.org/installer');" | php
+    - cd C:\projects\filesystem
+    - IF NOT %php_ver_target%=="8.0.0" composer update --prefer-stable --no-progress
+    - IF %php_ver_target%=="8.0.0" composer update --prefer-stable --no-progress --ignore-platform-req=php
+
+test_script:
+  - cd C:\projects\filesystem
+  - vendor\bin\phpunit

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -26,6 +26,7 @@ local phpunit(phpversion) = {
     name: "PHPUnit",
     image: "joomlaprojects/docker-images:php" + phpversion,
     [if phpversion == "8.0" then "failure"]: "ignore",
+    [if phpversion == "8.1" then "failure"]: "ignore",
     commands: ["vendor/bin/phpunit"]
 };
 
@@ -141,5 +142,6 @@ local pipeline(name, phpversion, params) = {
     pipeline("7.2", "7.2", "--prefer-stable"),
     pipeline("7.3", "7.3", "--prefer-stable"),
     pipeline("7.4", "7.4", "--prefer-stable"),
-    pipeline("8.0", "8.0", "--ignore-platform-reqs")
+    pipeline("8.0", "8.0", "--ignore-platform-reqs"),
+    pipeline("8.1", "8.1", "--ignore-platform-reqs")
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -106,7 +106,24 @@ local pipeline(name, phpversion, params) = {
             }
         ]
     },
-    pipeline("5.3 lowest", "5.3", "--prefer-stable --prefer-lowest"),
+    {
+        kind: "pipeline",
+        name: "PHP 5.3 lowest",
+        volumes: hostvolumes,
+        steps: [
+            {
+                name: "composer",
+                image: "joomlaprojects/docker-images:php5.3",
+                volumes: volumes,
+                commands: [
+                    "php -v",
+                    "composer update --prefer-stable --prefer-lowest",
+                    "composer update phpunit/phpunit-mock-objects"
+                ]
+            },
+            phpunit("5.3")
+        ]
+    },
     pipeline("5.3", "5.3", "--prefer-stable"),
     pipeline("5.6", "5.6", "--prefer-stable"),
     pipeline("7.0", "7.0", "--prefer-stable"),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -108,8 +108,6 @@ local pipeline(name, phpversion, params) = {
     },
     pipeline("5.3 lowest", "5.3", "--prefer-stable --prefer-lowest"),
     pipeline("5.3", "5.3", "--prefer-stable"),
-    pipeline("5.4", "5.4", "--prefer-stable"),
-    pipeline("5.5", "5.5", "--prefer-stable"),
     pipeline("5.6", "5.6", "--prefer-stable"),
     pipeline("7.0", "7.0", "--prefer-stable"),
     pipeline("7.1", "7.1", "--prefer-stable"),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -18,7 +18,9 @@ local composer(phpversion, params) = {
     volumes: volumes,
     commands: [
         "php -v",
-        "composer update " + params
+        "composer update " + params,
+        if phpversion == "8.0" then "composer require --dev --with-all-dependencies phpunit/phpunit:^8.0",
+        if phpversion == "8.1" then "composer require --dev --with-all-dependencies phpunit/phpunit:^8.0",
     ]
 };
 

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -56,12 +56,22 @@ local pipeline(name, phpversion, params) = {
                 ]
             },
             {
-                name: "phpcs",
+                name: "phpcs (loose)",
                 image: "joomlaprojects/docker-images:php7.4",
                 depends: [ "composer" ],
                 commands: [
                     "vendor/bin/phpcs --config-set installed_paths vendor/joomla/coding-standards",
                     "vendor/bin/phpcs -p --report=full --extensions=php --standard=ruleset.xml src/"
+                ]
+            },
+            {
+                name: "phpcs (strict)",
+                image: "joomlaprojects/docker-images:php7.4",
+                depends: [ "composer" ],
+                failure: "ignore",
+                commands: [
+                    "vendor/bin/phpcs --config-set installed_paths vendor/joomla/coding-standards",
+                    "vendor/bin/phpcs -p --report=full --extensions=php --standard=Joomla src/"
                 ]
             },
             {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -142,6 +142,6 @@ local pipeline(name, phpversion, params) = {
     pipeline("7.2", "7.2", "--prefer-stable"),
     pipeline("7.3", "7.3", "--prefer-stable"),
     pipeline("7.4", "7.4", "--prefer-stable"),
-    pipeline("8.0", "8.0", "--ignore-platform-reqs"),
-    pipeline("8.1", "8.1", "--ignore-platform-reqs")
+    pipeline("8.0", "8.0", "--prefer-stable"),
+    pipeline("8.1", "8.1", "--prefer-stable")
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,0 +1,120 @@
+local volumes = [
+    {
+        name: "composer-cache",
+        path: "/tmp/composer-cache",
+    },
+];
+
+local hostvolumes = [
+    {
+        name: "composer-cache",
+        host: {path: "/tmp/composer-cache"}
+    },
+];
+
+local composer(phpversion, params) = {
+    name: "composer",
+    image: "joomlaprojects/docker-images:php" + phpversion,
+    volumes: volumes,
+    commands: [
+        "php -v",
+        "composer update " + params
+    ]
+};
+
+local phpunit(phpversion) = {
+    name: "PHPUnit",
+    image: "joomlaprojects/docker-images:php" + phpversion,
+    [if phpversion == "8.0" then "failure"]: "ignore",
+    commands: ["vendor/bin/phpunit"]
+};
+
+local pipeline(name, phpversion, params) = {
+    kind: "pipeline",
+    name: "PHP " + name,
+    volumes: hostvolumes,
+    steps: [
+        composer(phpversion, params),
+        phpunit(phpversion)
+    ],
+};
+
+[
+    {
+        kind: "pipeline",
+        name: "Codequality",
+        volumes: hostvolumes,
+        steps: [
+            {
+                name: "composer",
+                image: "joomlaprojects/docker-images:php7.4",
+                volumes: volumes,
+                commands: [
+                    "php -v",
+                    "composer update --prefer-stable",
+                    "composer require phpmd/phpmd phpstan/phpstan"
+                ]
+            },
+            {
+                name: "phpcs",
+                image: "joomlaprojects/docker-images:php7.4",
+                depends: [ "composer" ],
+                commands: [
+                    "vendor/bin/phpcs --config-set installed_paths vendor/joomla/coding-standards",
+                    "vendor/bin/phpcs -p --report=full --extensions=php --standard=ruleset.xml src/"
+                ]
+            },
+            {
+                name: "phpmd",
+                image: "joomlaprojects/docker-images:php7.4",
+                depends: [ "composer" ],
+                failure: "ignore",
+                commands: [
+                    "vendor/bin/phpmd src text cleancode",
+                    "vendor/bin/phpmd src text codesize",
+                    "vendor/bin/phpmd src text controversial",
+                    "vendor/bin/phpmd src text design",
+                    "vendor/bin/phpmd src text unusedcode",
+                ]
+            },
+            {
+                name: "phpstan",
+                image: "joomlaprojects/docker-images:php7.4",
+                depends: [ "composer" ],
+                failure: "ignore",
+                commands: [
+                    "vendor/bin/phpstan analyse src",
+                ]
+            },
+            {
+                name: "phploc",
+                image: "joomlaprojects/docker-images:php7.4",
+                depends: [ "composer" ],
+                failure: "ignore",
+                commands: [
+                    "phploc src",
+                ]
+            },
+            {
+                name: "phpcpd",
+                image: "joomlaprojects/docker-images:php7.4",
+                depends: [ "composer" ],
+                failure: "ignore",
+                commands: [
+                    "phpcpd src",
+                ]
+            }
+        ]
+    },
+    pipeline("5.3 lowest", "5.3", "--prefer-stable --prefer-lowest"),
+    pipeline("5.3", "5.3", "--prefer-stable"),
+    pipeline("5.4", "5.4", "--prefer-stable"),
+    pipeline("5.5", "5.5", "--prefer-stable"),
+    pipeline("5.6", "5.6", "--prefer-stable"),
+    pipeline("7.0", "7.0", "--prefer-stable"),
+    pipeline("7.1", "7.1", "--prefer-stable"),
+    pipeline("7.2", "7.2", "--prefer-stable"),
+    pipeline("7.3", "7.3", "--prefer-stable"),
+    pipeline("7.4", "7.4", "--prefer-stable"),
+    pipeline("8.0", "8.0", "--ignore-platform-reqs")
+]

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,11 +17,18 @@ steps:
   - name: composer-cache
     path: /tmp/composer-cache
 
-- name: phpcs
+- name: phpcs (loose)
   image: joomlaprojects/docker-images:php7.4
   commands:
   - vendor/bin/phpcs --config-set installed_paths vendor/joomla/coding-standards
   - vendor/bin/phpcs -p --report=full --extensions=php --standard=ruleset.xml src/
+
+- name: phpcs (strict)
+  image: joomlaprojects/docker-images:php7.4
+  commands:
+  - vendor/bin/phpcs --config-set installed_paths vendor/joomla/coding-standards
+  - vendor/bin/phpcs -p --report=full --extensions=php --standard=Joomla src/
+  failure: ignore
 
 - name: phpmd
   image: joomlaprojects/docker-images:php7.4
@@ -312,6 +319,6 @@ volumes:
 
 ---
 kind: signature
-hmac: a6637e4d3053adf6e59b9afc5acda4c68da5f2b5ce83cedb7221343e6655c228
+hmac: bd5674e9e0abc663c8dab7e189873edb146769d0219d3b6c474c641dd69422f6
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -70,6 +70,7 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable --prefer-lowest
+  - composer update phpunit/phpunit-mock-objects
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -311,6 +312,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 07584183d0bd79e787a4532d6a2ff5cb0bc00cd573331cf19eea7f66982853af
+hmac: a6637e4d3053adf6e59b9afc5acda4c68da5f2b5ce83cedb7221343e6655c228
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,316 @@
+---
+kind: pipeline
+name: Codequality
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php7.4
+  commands:
+  - php -v
+  - composer update --prefer-stable
+  - composer require phpmd/phpmd phpstan/phpstan
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: phpcs
+  image: joomlaprojects/docker-images:php7.4
+  commands:
+  - vendor/bin/phpcs --config-set installed_paths vendor/joomla/coding-standards
+  - vendor/bin/phpcs -p --report=full --extensions=php --standard=ruleset.xml src/
+
+- name: phpmd
+  image: joomlaprojects/docker-images:php7.4
+  commands:
+  - vendor/bin/phpmd src text cleancode
+  - vendor/bin/phpmd src text codesize
+  - vendor/bin/phpmd src text controversial
+  - vendor/bin/phpmd src text design
+  - vendor/bin/phpmd src text unusedcode
+  failure: ignore
+
+- name: phpstan
+  image: joomlaprojects/docker-images:php7.4
+  commands:
+  - vendor/bin/phpstan analyse src
+  failure: ignore
+
+- name: phploc
+  image: joomlaprojects/docker-images:php7.4
+  commands:
+  - phploc src
+  failure: ignore
+
+- name: phpcpd
+  image: joomlaprojects/docker-images:php7.4
+  commands:
+  - phpcpd src
+  failure: ignore
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
+kind: pipeline
+name: PHP 5.3 lowest
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php5.3
+  commands:
+  - php -v
+  - composer update --prefer-stable --prefer-lowest
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: PHPUnit
+  image: joomlaprojects/docker-images:php5.3
+  commands:
+  - vendor/bin/phpunit
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
+kind: pipeline
+name: PHP 5.3
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php5.3
+  commands:
+  - php -v
+  - composer update --prefer-stable
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: PHPUnit
+  image: joomlaprojects/docker-images:php5.3
+  commands:
+  - vendor/bin/phpunit
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
+kind: pipeline
+name: PHP 5.6
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php5.6
+  commands:
+  - php -v
+  - composer update --prefer-stable
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: PHPUnit
+  image: joomlaprojects/docker-images:php5.6
+  commands:
+  - vendor/bin/phpunit
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
+kind: pipeline
+name: PHP 7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php7.0
+  commands:
+  - php -v
+  - composer update --prefer-stable
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: PHPUnit
+  image: joomlaprojects/docker-images:php7.0
+  commands:
+  - vendor/bin/phpunit
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
+kind: pipeline
+name: PHP 7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php7.1
+  commands:
+  - php -v
+  - composer update --prefer-stable
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: PHPUnit
+  image: joomlaprojects/docker-images:php7.1
+  commands:
+  - vendor/bin/phpunit
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
+kind: pipeline
+name: PHP 7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php7.2
+  commands:
+  - php -v
+  - composer update --prefer-stable
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: PHPUnit
+  image: joomlaprojects/docker-images:php7.2
+  commands:
+  - vendor/bin/phpunit
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
+kind: pipeline
+name: PHP 7.3
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php7.3
+  commands:
+  - php -v
+  - composer update --prefer-stable
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: PHPUnit
+  image: joomlaprojects/docker-images:php7.3
+  commands:
+  - vendor/bin/phpunit
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
+kind: pipeline
+name: PHP 7.4
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php7.4
+  commands:
+  - php -v
+  - composer update --prefer-stable
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: PHPUnit
+  image: joomlaprojects/docker-images:php7.4
+  commands:
+  - vendor/bin/phpunit
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
+kind: pipeline
+name: PHP 8.0
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php8.0
+  commands:
+  - php -v
+  - composer update --ignore-platform-reqs
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: PHPUnit
+  image: joomlaprojects/docker-images:php8.0
+  commands:
+  - vendor/bin/phpunit
+  failure: ignore
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
+kind: signature
+hmac: 07584183d0bd79e787a4532d6a2ff5cb0bc00cd573331cf19eea7f66982853af
+
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -301,7 +301,7 @@ steps:
   image: joomlaprojects/docker-images:php8.0
   commands:
   - php -v
-  - composer update --ignore-platform-reqs
+  - composer update --prefer-stable
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -330,7 +330,7 @@ steps:
   image: joomlaprojects/docker-images:php8.1
   commands:
   - php -v
-  - composer update --ignore-platform-reqs
+  - composer update --prefer-stable
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -348,6 +348,6 @@ volumes:
 
 ---
 kind: signature
-hmac: e3affc311774adf00c57e50320d30e5777e622cfd6c19325216f609cfd454970
+hmac: b4dd12c57a84baff111938c76c2733d8dcdb97ae85c10b7f44eec15298dc6a62
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -318,7 +318,36 @@ volumes:
     path: /tmp/composer-cache
 
 ---
+kind: pipeline
+name: PHP 8.1
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: composer
+  image: joomlaprojects/docker-images:php8.1
+  commands:
+  - php -v
+  - composer update --ignore-platform-reqs
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+
+- name: PHPUnit
+  image: joomlaprojects/docker-images:php8.1
+  commands:
+  - vendor/bin/phpunit
+  failure: ignore
+
+volumes:
+- name: composer-cache
+  host:
+    path: /tmp/composer-cache
+
+---
 kind: signature
-hmac: bd5674e9e0abc663c8dab7e189873edb146769d0219d3b6c474c641dd69422f6
+hmac: e3affc311774adf00c57e50320d30e5777e622cfd6c19325216f609cfd454970
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -106,6 +106,8 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
+  - ""
+  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -134,6 +136,8 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
+  - ""
+  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -162,6 +166,8 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
+  - ""
+  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -190,6 +196,8 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
+  - ""
+  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -218,6 +226,8 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
+  - ""
+  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -246,6 +256,8 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
+  - ""
+  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -274,6 +286,8 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
+  - ""
+  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -302,6 +316,8 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
+  - composer require --dev --with-all-dependencies phpunit/phpunit:^8.0
+  - ""
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -331,6 +347,8 @@ steps:
   commands:
   - php -v
   - composer update --prefer-stable
+  - ""
+  - composer require --dev --with-all-dependencies phpunit/phpunit:^8.0
   volumes:
   - name: composer-cache
     path: /tmp/composer-cache
@@ -348,6 +366,6 @@ volumes:
 
 ---
 kind: signature
-hmac: b4dd12c57a84baff111938c76c2733d8dcdb97ae85c10b7f44eec15298dc6a62
+hmac: 61294c1e4ecdb0919d3f5df7132900f6d02b1a1de6d6cfb1222ad606a83a2a21
 
 ...

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# Unix-style newlines with a newline ending every file
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,10 @@
+.github/ export-ignore
+docs/ export-ignore
+Tests/ export-ignore
+.appveyor.yml export-ignore
+.drone.jsonnet export-ignore
+.drone.yml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.travis.yml export-ignore
+phpunit.xml.dist export-ignore
+ruleset.xml export-ignore

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to the Joomla! Framework
 
-Please review [http://framework.joomla.org/contribute](http://framework.joomla.org/contribute) for information on how to contribute to the Framework's development.
+Please review [https://framework.joomla.org/contribute](https://framework.joomla.org/contribute) for information on how to contribute to the Framework's development.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor/
-composer.phar
 composer.lock
 phpunit.xml
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -5,7 +5,16 @@
 [![Latest Unstable Version](https://poser.pugx.org/joomla/test/v/unstable)](https://packagist.org/packages/joomla/test)
 [![License](https://poser.pugx.org/joomla/test/license)](https://packagist.org/packages/joomla/test)
 
-This package is a collection of tools that make some of the jobs of unit testing easier.
+This package is a collection of tools that make some jobs of unit testing easier.
+
+## TestCase
+
+With version 7.0, PHPUnit added return type declarations to its TestCase class.
+Tests running fine PHP < 7.2 will not work on current PHP versions,
+because the signatures do not match.
+
+This package provides a comatibility layer catering for that issue since version 1.4.0.
+Just extend your test classes from Joomla\Test\TestCase instead of PHPUnit\Framework\TestCase.
 
 ## TestHelper
 
@@ -165,12 +174,12 @@ class FooTest extends \PHPUnit_Framework_TestCase
 
 ## Installation via Composer
 
-Add `"joomla/test": "~1.0"` to the require block in your composer.json and then run `composer install`.
+Add `"joomla/test": "^1.4.0"` to the require-dev block in your composer.json and then run `composer install`.
 
 ```json
 {
-	"require": {
-		"joomla/test": "~1.0"
+	"require-dev": {
+		"joomla/test": "^1.4.0"
 	}
 }
 ```
@@ -178,5 +187,5 @@ Add `"joomla/test": "~1.0"` to the require block in your composer.json and then 
 Alternatively, you can simply run the following from the command line:
 
 ```sh
-composer require joomla/test "~1.0"
+composer require -- dev joomla/test "^1.4.0"
 ```

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     },
     "require-dev": {
         "joomla/database": "~1.0",
-        "phpunit/dbunit": "~1.3|~2.0",
         "joomla/coding-standards": "^2.0@alpha",
         "phpunit/phpunit": "^4.8.35|^5.4.3|^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     },
     "require-dev": {
         "joomla/database": "~1.0",
-        "phpunit/dbunit": "~1.3|~2.0"
+        "phpunit/dbunit": "~1.3|~2.0",
+        "joomla/coding-standards": "~2.0@alpha"
     },
     "suggest": {
         "joomla/database": "To use the database test case, install joomla/database",

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,7 @@
     "name": "joomla/test",
     "type": "joomla-package",
     "description": "Joomla Test Helper Package",
-    "keywords": [
-        "joomla",
-        "framework",
-        "unit test",
-        "phpunit",
-        "reflection"
-    ],
+    "keywords": ["joomla", "framework", "unit test", "phpunit", "reflection"],
     "homepage": "https://github.com/joomla-framework/test",
     "license": "GPL-2.0-or-later",
     "require": {
@@ -18,8 +12,7 @@
     "require-dev": {
         "joomla/database": "~1.0",
         "phpunit/dbunit": "~1.3|~2.0",
-        "joomla/coding-standards": "~2.0@alpha",
-        "phpunit/phpunit": "^4.8.36|^5.4.3|^6.0|^7.0|^8.0"
+        "joomla/coding-standards": "~2.0@alpha"
     },
     "suggest": {
         "joomla/database": "To use the database test case, install joomla/database",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,13 @@
     "name": "joomla/test",
     "type": "joomla-package",
     "description": "Joomla Test Helper Package",
-    "keywords": ["joomla", "framework", "unit test", "phpunit", "reflection"],
+    "keywords": [
+        "joomla",
+        "framework",
+        "unit test",
+        "phpunit",
+        "reflection"
+    ],
     "homepage": "https://github.com/joomla-framework/test",
     "license": "GPL-2.0-or-later",
     "require": {
@@ -12,7 +18,8 @@
     "require-dev": {
         "joomla/database": "~1.0",
         "phpunit/dbunit": "~1.3|~2.0",
-        "joomla/coding-standards": "~2.0@alpha"
+        "joomla/coding-standards": "~2.0@alpha",
+        "phpunit/phpunit": "^4.8.36|^5.4.3|^6.0|^7.0|^8.0"
     },
     "suggest": {
         "joomla/database": "To use the database test case, install joomla/database",

--- a/composer.json
+++ b/composer.json
@@ -2,17 +2,24 @@
     "name": "joomla/test",
     "type": "joomla-package",
     "description": "Joomla Test Helper Package",
-    "keywords": ["joomla", "framework", "unit test", "phpunit", "reflection"],
+    "keywords": [
+        "joomla",
+        "framework",
+        "unit test",
+        "phpunit",
+        "reflection"
+    ],
     "homepage": "https://github.com/joomla-framework/test",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^5.3.10|~7.0",
+        "php": "^5.3.10|^7.0|^8.0",
         "phpunit/phpunit": "^4.8.35|^5.4.3|~6.0|~7.0"
     },
     "require-dev": {
         "joomla/database": "~1.0",
         "phpunit/dbunit": "~1.3|~2.0",
-        "joomla/coding-standards": "~2.0@alpha"
+        "joomla/coding-standards": "^2.0@alpha",
+        "phpunit/phpunit": "^4.8.35|^5.4.3|^6.0"
     },
     "suggest": {
         "joomla/database": "To use the database test case, install joomla/database",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
 	</testsuites>
     <php>
 		<env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
-		<const name="JPATH_ROOT" value="__DIR__"/>
 	</php>
 
 	<!--

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="false">
+	<testsuites>
+		<testsuite name="Unit">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
+    <php>
+		<env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+		<const name="JPATH_ROOT" value="__DIR__"/>
+	</php>
+
+	<!--
+	<logging>
+		<log type="coverage-clover" target="build/logs/clover.xml" />
+		<log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false" />
+	</logging>
+	-->
+
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">src</directory>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -19,7 +19,9 @@
 		<exclude name="Joomla.NamingConventions.ValidFunctionName.MethodUnderscore"/>
 		<!-- Required due to methods named with snake case -->
 		<exclude name="Joomla.NamingConventions.ValidFunctionName.ScopeNotCamelCaps"/>
-		<exclude name="Joomla.NamingConventions.ValidVariableName.ScopeNotCamelCaps"/>
+		<exclude name="Joomla.NamingConventions.ValidFunctionName.NotCamelCaps"/>
+		<exclude name="Joomla.NamingConventions.ValidVariableName.ClassVarHasUnderscore"/>
+		<exclude name="Joomla.NamingConventions.ValidVariableName.MemberNotCamelCaps"/>
 	</rule>
 
 	<rule ref="Joomla.Classes.InstantiateNewClasses">

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,25 +1,30 @@
 <?xml version="1.0"?>
 <ruleset name="Joomla">
 
-    <arg name="report" value="full"/>
-    <arg name="tab-width" value="4"/>
-    <arg name="encoding" value="utf-8"/>
-    <arg value="sp"/>
-    <arg name="colors" />
+	<arg name="report" value="full"/>
+	<arg name="tab-width" value="4"/>
+	<arg name="encoding" value="utf-8"/>
+	<arg value="sp"/>
+	<arg name="colors"/>
 
-    <!-- Exclude folders not containing production code -->
-    <exclude-pattern>*/.github/*</exclude-pattern>
+	<!-- Exclude folders not containing production code -->
+	<exclude-pattern>*/.github/*</exclude-pattern>
 
-    <!-- Exclude 3rd party libraries. -->
-    <exclude-pattern>*/vendor/*</exclude-pattern>
+	<!-- Exclude 3rd party libraries. -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-    <rule ref="Joomla">
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
-    </rule>
+	<rule ref="Joomla">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<!-- Required due to methods being named _ -->
+		<exclude name="Joomla.NamingConventions.ValidFunctionName.MethodUnderscore"/>
+		<!-- Required due to methods named with snake case -->
+		<exclude name="Joomla.NamingConventions.ValidFunctionName.ScopeNotCamelCaps"/>
+		<exclude name="Joomla.NamingConventions.ValidVariableName.ScopeNotCamelCaps"/>
+	</rule>
 
-    <rule ref="Joomla.Classes.InstantiateNewClasses">
-        <properties>
-            <property name="shortArraySyntax" value="true"/>
-        </properties>
-    </rule>
+	<rule ref="Joomla.Classes.InstantiateNewClasses">
+		<properties>
+			<property name="shortArraySyntax" value="true"/>
+		</properties>
+	</rule>
 </ruleset>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -22,6 +22,7 @@
 		<exclude name="Joomla.NamingConventions.ValidFunctionName.NotCamelCaps"/>
 		<exclude name="Joomla.NamingConventions.ValidVariableName.ClassVarHasUnderscore"/>
 		<exclude name="Joomla.NamingConventions.ValidVariableName.MemberNotCamelCaps"/>
+		<exclude name="Joomla.NamingConventions.ValidVariableName.NotCamelCaps"/>
 	</rule>
 
 	<rule ref="Joomla.Classes.InstantiateNewClasses">

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset name="Joomla">
+
+    <arg name="report" value="full"/>
+    <arg name="tab-width" value="4"/>
+    <arg name="encoding" value="utf-8"/>
+    <arg value="sp"/>
+    <arg name="colors" />
+
+    <!-- Exclude folders not containing production code -->
+    <exclude-pattern>*/.github/*</exclude-pattern>
+
+    <!-- Exclude 3rd party libraries. -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <rule ref="Joomla">
+        <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+    </rule>
+
+    <rule ref="Joomla.Classes.InstantiateNewClasses">
+        <properties>
+            <property name="shortArraySyntax" value="true"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/src/PHPUnit/CompatTestCase.php
+++ b/src/PHPUnit/CompatTestCase.php
@@ -13,6 +13,8 @@ if (version_compare($versionClass::id(), '7.0', '>='))
 {
 	/**
 	 * Compatibility test case used for PHPUnit 7.x and later
+	 *
+	 * @since 1.4.0
 	 */
 	abstract class TestCase extends PhpUnit7TestCase
 	{
@@ -22,6 +24,8 @@ else
 {
 	/**
 	 * Compatibility test case used for PHPUnit 6.x and earlier
+	 *
+	 * @since 1.4.0
 	 */
 	abstract class TestCase extends PhpUnit6TestCase
 	{

--- a/src/PHPUnit/CompatTestCase.php
+++ b/src/PHPUnit/CompatTestCase.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Test\PHPUnit;
+
+$versionClass = class_exists('\\PHPUnit\\Runner\\Version') ? '\\PHPUnit\\Runner\\Version' : '\\PHPUnit_Runner_Version';
+
+// Note, the compatibility classes MUST be in separate files so as to not introduce parse errors for older PHP versions
+if (version_compare($versionClass::id(), '7.0', '>='))
+{
+	/**
+	 * Compatibility test case used for PHPUnit 7.x and later
+	 */
+	abstract class TestCase extends PhpUnit7TestCase
+	{
+	}
+}
+else
+{
+	/**
+	 * Compatibility test case used for PHPUnit 6.x and earlier
+	 */
+	abstract class TestCase extends PhpUnit6TestCase
+	{
+	}
+}

--- a/src/PHPUnit/PhpUnit6TestCase.php
+++ b/src/PHPUnit/PhpUnit6TestCase.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Test\PHPUnit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Compatibility test case used for PHPUnit 6.x and earlier
+ */
+abstract class PhpUnit6TestCase extends TestCase
+{
+	/**
+	 * This method is called before the first test of this test class is run.
+	 */
+	public static function setUpBeforeClass()
+	{
+		self::doSetUpBeforeClass();
+	}
+
+	/**
+	 * This method is called after the last test of this test class is run.
+	 */
+	public static function tearDownAfterClass()
+	{
+		self::doTearDownAfterClass();
+	}
+
+	/**
+	 * Sets up the fixture, for example, open a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp()
+	{
+		$this->doSetUp();
+	}
+
+	/**
+	 * Tears down the fixture, for example, close a network connection.
+	 * This method is called after a test is executed.
+	 */
+	protected function tearDown()
+	{
+		$this->doTearDown();
+	}
+
+	/**
+	 * Compatibility method for `setUpBeforeClass()`
+	 */
+	protected static function doSetUpBeforeClass()
+	{
+		parent::setUpBeforeClass();
+	}
+
+	/**
+	 * Compatibility method for `tearDownAfterClass()`
+	 */
+	protected static function doTearDownAfterClass()
+	{
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Compatibility method for `setUp()`
+	 */
+	protected function doSetUp()
+	{
+		parent::setUp();
+	}
+
+	/**
+	 * Compatibility method for `tearDown()`
+	 */
+	protected function doTearDown()
+	{
+		parent::tearDown();
+	}
+}

--- a/src/PHPUnit/PhpUnit6TestCase.php
+++ b/src/PHPUnit/PhpUnit6TestCase.php
@@ -10,11 +10,15 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Compatibility test case used for PHPUnit 6.x and earlier
+ *
+ * @since 1.4.0
  */
 abstract class PhpUnit6TestCase extends TestCase
 {
 	/**
 	 * This method is called before the first test of this test class is run.
+	 *
+	 * @return void
 	 */
 	public static function setUpBeforeClass()
 	{
@@ -23,6 +27,8 @@ abstract class PhpUnit6TestCase extends TestCase
 
 	/**
 	 * This method is called after the last test of this test class is run.
+	 *
+	 * @return void
 	 */
 	public static function tearDownAfterClass()
 	{
@@ -31,6 +37,8 @@ abstract class PhpUnit6TestCase extends TestCase
 
 	/**
 	 * Sets up the fixture, for example, open a network connection.
+	 *
+	 * @return void
 	 * This method is called before a test is executed.
 	 */
 	protected function setUp()
@@ -41,6 +49,8 @@ abstract class PhpUnit6TestCase extends TestCase
 	/**
 	 * Tears down the fixture, for example, close a network connection.
 	 * This method is called after a test is executed.
+	 *
+	 * @return void
 	 */
 	protected function tearDown()
 	{
@@ -49,6 +59,8 @@ abstract class PhpUnit6TestCase extends TestCase
 
 	/**
 	 * Compatibility method for `setUpBeforeClass()`
+	 *
+	 * @return void
 	 */
 	protected static function doSetUpBeforeClass()
 	{
@@ -57,6 +69,8 @@ abstract class PhpUnit6TestCase extends TestCase
 
 	/**
 	 * Compatibility method for `tearDownAfterClass()`
+	 *
+	 * @return void
 	 */
 	protected static function doTearDownAfterClass()
 	{
@@ -65,6 +79,8 @@ abstract class PhpUnit6TestCase extends TestCase
 
 	/**
 	 * Compatibility method for `setUp()`
+	 *
+	 * @return void
 	 */
 	protected function doSetUp()
 	{
@@ -73,6 +89,8 @@ abstract class PhpUnit6TestCase extends TestCase
 
 	/**
 	 * Compatibility method for `tearDown()`
+	 *
+	 * @return void
 	 */
 	protected function doTearDown()
 	{

--- a/src/PHPUnit/PhpUnit7TestCase.php
+++ b/src/PHPUnit/PhpUnit7TestCase.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Test\PHPUnit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Compatibility test case used for PHPUnit 7.x and later
+ */
+abstract class PhpUnit7TestCase extends TestCase
+{
+	/**
+	 * This method is called before the first test of this test class is run.
+	 */
+	public static function setUpBeforeClass(): void
+	{
+		self::doSetUpBeforeClass();
+	}
+
+	/**
+	 * This method is called after the last test of this test class is run.
+	 */
+	public static function tearDownAfterClass(): void
+	{
+		self::doTearDownAfterClass();
+	}
+
+	/**
+	 * Sets up the fixture, for example, open a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp(): void
+	{
+		$this->doSetUp();
+	}
+
+	/**
+	 * Tears down the fixture, for example, close a network connection.
+	 * This method is called after a test is executed.
+	 */
+	protected function tearDown(): void
+	{
+		$this->doTearDown();
+	}
+
+	/**
+	 * Compatibility method for `setUpBeforeClass()`
+	 */
+	protected static function doSetUpBeforeClass()
+	{
+		parent::setUpBeforeClass();
+	}
+
+	/**
+	 * Compatibility method for `tearDownAfterClass()`
+	 */
+	protected static function doTearDownAfterClass()
+	{
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Compatibility method for `setUp()`
+	 */
+	protected function doSetUp()
+	{
+		parent::setUp();
+	}
+
+	/**
+	 * Compatibility method for `tearDown()`
+	 */
+	protected function doTearDown()
+	{
+		parent::tearDown();
+	}
+}

--- a/src/PHPUnit/PhpUnit7TestCase.php
+++ b/src/PHPUnit/PhpUnit7TestCase.php
@@ -10,11 +10,15 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Compatibility test case used for PHPUnit 7.x and later
+ *
+ * @since 1.4.0
  */
 abstract class PhpUnit7TestCase extends TestCase
 {
 	/**
 	 * This method is called before the first test of this test class is run.
+	 *
+	 * @return void
 	 */
 	public static function setUpBeforeClass(): void
 	{
@@ -23,6 +27,8 @@ abstract class PhpUnit7TestCase extends TestCase
 
 	/**
 	 * This method is called after the last test of this test class is run.
+	 *
+	 * @return void
 	 */
 	public static function tearDownAfterClass(): void
 	{
@@ -32,6 +38,8 @@ abstract class PhpUnit7TestCase extends TestCase
 	/**
 	 * Sets up the fixture, for example, open a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @return void
 	 */
 	protected function setUp(): void
 	{
@@ -41,6 +49,8 @@ abstract class PhpUnit7TestCase extends TestCase
 	/**
 	 * Tears down the fixture, for example, close a network connection.
 	 * This method is called after a test is executed.
+	 *
+	 * @return void
 	 */
 	protected function tearDown(): void
 	{
@@ -49,6 +59,8 @@ abstract class PhpUnit7TestCase extends TestCase
 
 	/**
 	 * Compatibility method for `setUpBeforeClass()`
+	 *
+	 * @return void
 	 */
 	protected static function doSetUpBeforeClass()
 	{
@@ -57,6 +69,8 @@ abstract class PhpUnit7TestCase extends TestCase
 
 	/**
 	 * Compatibility method for `tearDownAfterClass()`
+	 *
+	 * @return void
 	 */
 	protected static function doTearDownAfterClass()
 	{
@@ -65,6 +79,8 @@ abstract class PhpUnit7TestCase extends TestCase
 
 	/**
 	 * Compatibility method for `setUp()`
+	 *
+	 * @return void
 	 */
 	protected function doSetUp()
 	{
@@ -73,6 +89,8 @@ abstract class PhpUnit7TestCase extends TestCase
 
 	/**
 	 * Compatibility method for `tearDown()`
+	 *
+	 * @return void
 	 */
 	protected function doTearDown()
 	{

--- a/src/WebInspector.php
+++ b/src/WebInspector.php
@@ -19,25 +19,33 @@ use Joomla\Application\AbstractWebApplication;
 class WebInspector extends AbstractWebApplication
 {
 	/**
-	 * @var     boolean  True to mimic the headers already being sent.
+	 * True to mimic the headers already being sent.
+	 *
+	 * @var     boolean
 	 * @since   1.0
 	 */
 	public static $headersSent = false;
 
 	/**
-	 * @var     boolean  True to mimic the connection being alive.
+	 * True to mimic the connection being alive.
+	 *
+	 * @var     boolean
 	 * @since   1.0
 	 */
 	public static $connectionAlive = true;
 
 	/**
-	 * @var     array  List of sent headers for inspection. array($string, $replace, $code).
+	 * List of sent headers for inspection. array($string, $replace, $code).
+	 *
+	 * @var     array
 	 * @since   1.0
 	 */
 	public $headers = array();
 
 	/**
-	 * @var     integer  The exit code if the application was closed otherwise null.
+	 * The exit code if the application was closed otherwise null.
+	 *
+	 * @var     integer
 	 * @since   1.0
 	 */
 	public $closed;


### PR DESCRIPTION
### Summary of Changes

Add an alternative TestCase class that hides the issues with incompatible signatures for PHPUnit < 7.0 and PHPUnit >= 7.0.

### Testing Instructions

Take an existing test class working with PHPUnit < 7.0, extend it from Joomla\Test\TestCase instead of PHPUnit\Framework\TestCase.
Run the test with PHPUnit >= 7.0.
PHP should not complain about incompatible signatures.

### Documentation Changes Required

README was updated accordingly.